### PR TITLE
olo-gulp-helpers: add Webpack/TypeScript support

### DIFF
--- a/packages/olo-gulp-helpers/.npmrc
+++ b/packages/olo-gulp-helpers/.npmrc
@@ -1,0 +1,1 @@
+save-exact = true

--- a/packages/olo-gulp-helpers/package.json
+++ b/packages/olo-gulp-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "olo-gulp-helpers",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "description": "Helpers for Olo's gulp build pipeline",
   "main": "index.js",
   "scripts": {
@@ -11,19 +11,45 @@
     "url": "https://github.com/ololabs/javascript"
   },
   "dependencies": {
-    "babel-preset-es2015": "^6.5.0",
-    "eslint-teamcity": "^1.0.0",
-    "gulp": "^3.9.1",
-    "gulp-babel": "^6.1.2",
-    "gulp-concat": "^2.6.0",
-    "gulp-eslint": "^2.0.0",
-    "gulp-if": "^2.0.0",
-    "gulp-plumber": "^1.1.0",
-    "gulp-rev": "^7.0.0",
-    "gulp-sass": "^2.2.0",
-    "gulp-sourcemaps": "^1.6.0",
-    "gulp-uglify": "^1.5.2",
-    "merge-stream": "^1.0.0"
+    "babel-preset-es2015": "6.13.2",
+    "beautylog": "5.0.14",
+    "chai": "3.5.0",
+    "eslint-teamcity": "1.1.0",
+    "gulp": "3.9.1",
+    "gulp-babel": "6.1.2",
+    "gulp-concat": "2.6.0",
+    "gulp-eslint": "3.0.1",
+    "gulp-if": "2.0.1",
+    "gulp-plumber": "1.1.0",
+    "gulp-rev": "7.0.0",
+    "gulp-sass": "2.2.0",
+    "gulp-sourcemaps": "1.6.0",
+    "gulp-tslint": "6.0.2",
+    "gulp-typescript": "2.13.6",
+    "gulp-typings": "2.0.3",
+    "gulp-uglify": "1.5.2",
+    "gulp-webpack": "1.5.0",
+    "karma": "1.1.2",
+    "karma-chai": "0.1.0",
+    "karma-mocha": "1.1.1",
+    "karma-mocha-reporter": "2.1.0",
+    "karma-phantomjs-launcher": "1.0.1",
+    "karma-sinon-chai": "1.2.3",
+    "karma-teamcity-reporter": "1.0.0",
+    "karma-typescript-preprocessor2": "1.2.1",
+    "karma-webpack": "1.7.0",
+    "lodash": "4.14.1",
+    "merge-stream": "1.0.0",
+    "mocha": "3.0.1",
+    "sinon": "1.17.5",
+    "sinon-chai": "2.8.0",
+    "source-map-loader": "0.1.5",
+    "ts-loader": "0.8.2",
+    "tslint": "3.14.0",
+    "tslint-teamcity-reporter": "1.0.0",
+    "typescript": "1.8.10",
+    "webpack": "1.13.1",
+    "webpack-md5-hash": "0.0.5"
   },
   "keywords": [
     "olo",
@@ -37,6 +63,6 @@
   "homepage": "https://github.com/ololabs/javascript",
   "devDependencies": {
     "eslint": "^2.5.1",
-    "eslint-config-olo": "^0.1.0"
+    "eslint-config-olo": "^0.1.1"
   }
 }


### PR DESCRIPTION
This PR adds in support for Webpack bundles to our Gulp build pipeline. It also includes support for Typescript.

Remaining tasks:
- [x] Linting
- [x] Watch/partial builds
- [x] Verify TeamCity flow
- [x] Make sure builds fail appropriately for TS errors
- [x] remove alpha from version
- [x] see if we can decrease how badly npm impacts our built times first
- [x] incorporate test support...maybe?
