### PR TITLE
update sass version

### DIFF
--- a/packages/olo-gulp-helpers/package.json
+++ b/packages/olo-gulp-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "olo-gulp-helpers",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Helpers for Olo's gulp build pipeline",
   "main": "index.js",
   "scripts": {},
@@ -18,7 +18,7 @@
     "gulp-if": "^2.0.0",
     "gulp-plumber": "^1.1.0",
     "gulp-rev": "^7.0.0",
-    "gulp-sass": "^2.2.0",
+    "gulp-sass": "3.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.5.2",
     "merge-stream": "^1.0.0"


### PR DESCRIPTION
update deps to allow olo-gulp-helpers to work with Node 5+
@gshackles I wasn't sure how we normally patch previous versions but this is based off olo-gulp-helpers-v0.1.1

The goal is to update our build agents to Node LTS but gulp-sass complains unless updated. This update would allow Ghost to use an older version of olo-gulp-helpers and still use Node LTS.