### PR TITLE
Allow webpack output customizations.

### DIFF
--- a/packages/olo-gulp-helpers/helpers/scripts.js
+++ b/packages/olo-gulp-helpers/helpers/scripts.js
@@ -123,10 +123,14 @@ function createWebpackConfig(
     webpackConfig.loaders || []
   );
 
+  const output = Object.assign({},
+    webpackConfig.output || {},
+    { filename: baseName + "-[chunkhash].js" });
+
   return {
     devtool: "source-map",
     entry: { bundle: entryScriptPath },
-    output: { filename: baseName + "-[chunkhash].js" },
+    output: output,
     watch: watchMode,
     module: {
       loaders: loaders


### PR DESCRIPTION
I'd like to start introducing some Typescript code into some of Dashboard pages that are still utilizing jQuery and vanilla javascript.  That means being able to specify both `libraryTarget` and `library` in the output config for the webpack configuration. https://webpack.js.org/configuration/output/#outputlibrary

Currently, that value is cannot be changed via the child webpack configs.  