### PR TITLE
Add support for ES6 in a pre-bundle state [PLAT-20611]

### DIFF
--- a/packages/olo-gulp-helpers/helpers/scripts.js
+++ b/packages/olo-gulp-helpers/helpers/scripts.js
@@ -61,7 +61,9 @@ function createBundle(
     .src(bundleFiles)
     .pipe(gulpif(watchMode, plumber()))
     .pipe(sourcemaps.init())
-    .pipe(babel())
+    .pipe(babel({
+      presets: ["es2015"] // ensure that uglify does not choke on potential es6 code
+    }))
     .pipe(uglify())
     .pipe(concat({ path: bundleName, cwd: currentDirectory }))
     .pipe(rev())


### PR DESCRIPTION
Dashboard runs `gulp bundle` and can get in a state where ES6 code exists prior to that bundling. [Uglify does not handle ES6](https://github.com/mishoo/UglifyJS2/issues/659#issuecomment-427063804), so we need to ensure that Babel transpiles it.

[PLAT-20611](https://ololabs.atlassian.net/browse/PLAT-20611)