### PR TITLE
Support escaped unicode characters in sass bundling

### DIFF
--- a/packages/olo-gulp-helpers/helpers/styles.js
+++ b/packages/olo-gulp-helpers/helpers/styles.js
@@ -6,6 +6,8 @@ const concat = require("gulp-concat");
 const rev = require("gulp-rev");
 const sourcemaps = require("gulp-sourcemaps");
 const sass = require("gulp-dart-sass");
+const sassUnicode = require("gulp-sass-unicode");
+const stripBom = require("gulp-stripbom");
 const gulpif = require("gulp-if");
 const plumber = require("gulp-plumber");
 
@@ -27,6 +29,8 @@ function createBundle(
         outputStyle: "compressed"
       })
     )
+    .pipe(sassUnicode())
+    .pipe(stripBom({ showLog: false }))
     .pipe(concat({ path: bundleName, cwd: currentDirectory }))
     .pipe(rev())
     .pipe(sourcemaps.write("."))

--- a/packages/olo-gulp-helpers/package.json
+++ b/packages/olo-gulp-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "olo-gulp-helpers",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Helpers for Olo's gulp build pipeline",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,9 @@
     "gulp-if": "2.0.2",
     "gulp-plumber": "1.2.0",
     "gulp-rev": "8.1.1",
+    "gulp-sass-unicode": "1.0.5",
     "gulp-sourcemaps": "2.6.4",
+    "gulp-stripbom": "1.0.5",
     "gulp-terser": "1.2.0",
     "gulp-tslint": "8.1.3",
     "gulp-typescript": "4.0.0",

--- a/tests/sample-webapp/asset-config.json
+++ b/tests/sample-webapp/asset-config.json
@@ -3,7 +3,7 @@
         "babel-included.js": ["src/babel-included.js"],
         "babel-excluded.js": ["src/babel-excluded.js"],
         "main.js": ["src/gulp-app.js"],
-        "main.css": ["src/app.scss"]
+        "main.css": ["src/app.scss", "src/unicode.scss"]
     },
     "webpack": {
         "webpack-app.js": "src/webpack-app.js",

--- a/tests/sample-webapp/src/unicode.scss
+++ b/tests/sample-webapp/src/unicode.scss
@@ -1,0 +1,3 @@
+.escaped-unicode {
+    content: '\f03a';
+}

--- a/tests/sample-webapp/tests/tests.js
+++ b/tests/sample-webapp/tests/tests.js
@@ -85,6 +85,10 @@ describe('styles', () => {
                 `body{font-family:"Courier New",Courier,monospace;color:#639}` // we are checking the hex value because the sass compiler does not preserve color names
             )
         );
+        assert.ok(
+            !builtBundle.includes('\uFEFF'), // BOM
+            'No BOM characters should be in the bundle.'
+        );
     });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3555,7 +3555,7 @@ chalk@2.3.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.2.0"
 
-chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -5367,6 +5367,11 @@ fined@^1.0.1:
     object.pick "^1.2.0"
     parse-filepath "^1.0.1"
 
+first-chunk-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz#59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
+  integrity sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=
+
 first-chunk-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz#1bdecdb8e083c0664b91945581577a43a9f31d70"
@@ -5938,6 +5943,15 @@ gulp-rev@8.1.1:
     vinyl "^2.1.0"
     vinyl-file "^3.0.0"
 
+gulp-sass-unicode@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/gulp-sass-unicode/-/gulp-sass-unicode-1.0.5.tgz#ea751dc4556aa0010e12ef51f97910ace1ffa179"
+  integrity sha512-CiV9RpZWKbKKmgz+tw9a0xyCDljYkVqX3rmMV6mfsUpSyqMhP7I5lfoZaF4S81vJaqMxhORQmQWptB8kVBGxRA==
+  dependencies:
+    gulp "^4.0.0"
+    plugin-error "^1.0.1"
+    through2 "^3.0.1"
+
 gulp-sourcemaps@2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/gulp-sourcemaps/-/gulp-sourcemaps-2.6.4.tgz#cbb2008450b1bcce6cd23bf98337be751bf6e30a"
@@ -5954,6 +5968,18 @@ gulp-sourcemaps@2.6.4:
     source-map "~0.6.0"
     strip-bom-string "1.X"
     through2 "2.X"
+
+gulp-stripbom@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/gulp-stripbom/-/gulp-stripbom-1.0.5.tgz#37ebd91d68c0c3b1861d66f055880417c9a304fe"
+  integrity sha512-0mThhGKerVFgXVPM6BSlleXym+K0Txkzx+CMaOmpMjScm1UZ4FIvuQiAQme0oYm3lhMwrbDQkiDtYbuve64l0Q==
+  dependencies:
+    ansi-colors "^4.1.1"
+    fancy-log "^1.3.3"
+    log-symbols "^1.0.0"
+    plugin-error "^1.0.1"
+    strip-bom "^1.0.0"
+    through2 "^0.5.1"
 
 gulp-terser@1.2.0:
   version "1.2.0"
@@ -5988,7 +6014,7 @@ gulp-typescript@4.0.0:
     through2 "^2.0.3"
     vinyl-fs "^3.0.0"
 
-gulp@4.0.2, gulp@^4.0.2:
+gulp@4.0.2, gulp@^4.0.0, gulp@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/gulp/-/gulp-4.0.2.tgz#543651070fd0f6ab0a0650c6a3e6ff5a7cb09caa"
   integrity sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==
@@ -6716,6 +6742,11 @@ is-wsl@^2.1.1:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -7637,6 +7668,13 @@ log-symbols@3.0.0:
   dependencies:
     chalk "^2.4.2"
 
+log-symbols@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
+  dependencies:
+    chalk "^1.0.0"
+
 log-symbols@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
@@ -8012,7 +8050,7 @@ minimist-options@^4.0.2:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@1.2.5, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -9420,6 +9458,16 @@ read@1, read@~1.0.1:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-stream@~1.0.17:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readdir-scoped-modules@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz#8d45407b4f870a0dcaebc0e28670d18e74514309"
@@ -10377,6 +10425,11 @@ string_decoder@^1.0.0, string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -10440,6 +10493,14 @@ strip-bom-string@1.X:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom-string/-/strip-bom-string-1.0.0.tgz#e5211e9224369fbb81d633a2f00044dc8cedad92"
   integrity sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=
+
+strip-bom@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-1.0.0.tgz#85b8862f3844b5a6d5ec8467a93598173a36f794"
+  integrity sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=
+  dependencies:
+    first-chunk-stream "^1.0.0"
+    is-utf8 "^0.2.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -10705,6 +10766,14 @@ through2@2.X, through2@^2.0.0, through2@^2.0.1, through2@^2.0.2, through2@^2.0.3
   dependencies:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
+
+through2@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.5.1.tgz#dfdd012eb9c700e2323fd334f38ac622ab372da7"
+  integrity sha1-390BLrnHAOIyP9M084rGIqs3Lac=
+  dependencies:
+    readable-stream "~1.0.17"
+    xtend "~3.0.0"
 
 through2@^3.0.0, through2@^3.0.1:
   version "3.0.2"
@@ -11661,6 +11730,11 @@ xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+xtend@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-3.0.0.tgz#5cce7407baf642cba7becda568111c493f59665a"
+  integrity sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
When encountering a unicode character, `dart-sass` will encode output file as UTF-8 BOM. Then, `concat` will keep the BOM character during bundling, resulting in an invalid css bundle. This edge case was identified by Call Center when bundling FontAwesome css.

To mitigate:
* use `gulp-sass-unicode` to convert unicode characters back to escaped characters
* use `gulp-stripbom` to remove the BOM character within a css bundled